### PR TITLE
Add RS256 (used by GitHub)

### DIFF
--- a/doctests.hs
+++ b/doctests.hs
@@ -1,3 +1,4 @@
 import Test.DocTest
 
+main :: IO ()
 main = doctest ["-isrc", "src/Web"]

--- a/jwt.cabal
+++ b/jwt.cabal
@@ -31,7 +31,7 @@ source-repository head
 library
   exposed-modules:     Web.JWT
   other-modules:       Data.Text.Extended, Data.ByteString.Extended
-  build-depends:       base >= 4.6 && < 4.9
+  build-depends:       base >= 4.6 && < 5.0
                      , cryptonite               >= 0.6
                      , memory                   >= 0.8
                      , bytestring               >= 0.10

--- a/jwt.cabal
+++ b/jwt.cabal
@@ -46,6 +46,8 @@ library
                      , vector                   >= 0.7.1
                      , semigroups               >= 0.15.4
                      , network-uri
+                     , RSA
+                     , HsOpenSSL
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -90,6 +92,8 @@ test-suite testsuite
                      , vector                   >= 0.7.1
                      , semigroups               >= 0.15.4
                      , network-uri
+                     , RSA
+                     , HsOpenSSL
 
   cpp-options: -DTEST
 

--- a/src/Web/JWT.hs
+++ b/src/Web/JWT.hs
@@ -13,11 +13,11 @@ Maintainer:  Stefan Saasen <stefan@saasen.me>
 Stability:   experimental
 
 This implementation of JWT is based on <https://tools.ietf.org/html/rfc7519>
-but currently only implements the minimum required to work with the Atlassian Connect framework.
+but currently only implements the minimum required to work with the Atlassian Connect framework and GitHub App
 
 Known limitations:
 
-   * Only HMAC SHA-256 algorithm is currently a supported signature algorithm
+   * Only HMAC SHA-256 and RSA SHA-256 algorithms are currently a supported signature algorithm
 
    * There is currently no verification of time related information
    ('exp', 'nbf', 'iat').

--- a/src/Web/JWT.hs
+++ b/src/Web/JWT.hs
@@ -67,7 +67,7 @@ module Web.JWT
     , JSON
     , Algorithm(..)
     , JWTClaimsSet(..)
-    , ClaimsMap
+    , ClaimsMap(..)
     , IntDate
     , NumericDate
     , StringOrURI
@@ -250,7 +250,7 @@ data JWTClaimsSet = JWTClaimsSet {
 
 
 instance Default JWTClaimsSet where
-    def = JWTClaimsSet Nothing Nothing Nothing Nothing Nothing Nothing Nothing Map.empty
+    def = JWTClaimsSet Nothing Nothing Nothing Nothing Nothing Nothing Nothing $ ClaimsMap Map.empty
 
 
 -- | Encode a claims set using the given secret
@@ -266,13 +266,13 @@ instance Default JWTClaimsSet where
 -- @
 -- > "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZSwiaXNzIjoiRm9vIn0.vHQHuG3ujbnBUmEp-fSUtYxk27rLiP2hrNhxpyWhb2E"
 encodeSigned :: Algorithm -> Secret -> JWTClaimsSet -> JSON
-encodeSigned algo secret claims = dotted [header, claim, signature]
-    where claim     = encodeJWT claims
-          header    = encodeJWT def {
+encodeSigned algo secret' claims' = dotted [header', claim, signature']
+    where claim     = encodeJWT claims'
+          header'   = encodeJWT def {
                         typ = Just "JWT"
                       , alg = Just algo
                       }
-          signature = calculateDigest algo secret (dotted [header, claim])
+          signature' = calculateDigest algo secret' (dotted [header', claim])
 
 -- | Encode a claims set without signing it
 --
@@ -287,9 +287,9 @@ encodeSigned algo secret claims = dotted [header, claim, signature]
 --  @
 -- > "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjEzOTQ3MDA5MzQsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlLCJpc3MiOiJGb28ifQ."
 encodeUnsigned :: JWTClaimsSet -> JSON
-encodeUnsigned claims = dotted [header, claim, ""]
-    where claim     = encodeJWT claims
-          header    = encodeJWT def {
+encodeUnsigned claims' = dotted [header', claim, ""]
+    where claim     = encodeJWT claims'
+          header'   = encodeJWT def {
                         typ = Just "JWT"
                       , alg = Just HS256
                       }
@@ -315,7 +315,7 @@ encodeUnsigned claims = dotted [header, claim, ""]
 --      mJwt = decode input
 --  in fmap claims mJwt
 -- :}
--- Just (JWTClaimsSet {iss = Nothing, sub = Nothing, aud = Nothing, exp = Nothing, nbf = Nothing, iat = Nothing, jti = Nothing, unregisteredClaims = fromList [("some",String "payload")]})
+-- Just (JWTClaimsSet {iss = Nothing, sub = Nothing, aud = Nothing, exp = Nothing, nbf = Nothing, iat = Nothing, jti = Nothing, unregisteredClaims = ClaimsMap {unClaimsMap = fromList [("some",String "payload")]}})
 decode :: JSON -> Maybe (JWT UnverifiedJWT)
 decode input = do
     (h,c,s) <- extractElems $ T.splitOn "." input
@@ -475,13 +475,14 @@ calculateDigest _ _ _ = error "Invalid use of calculateDigest"
 
 -- =================================================================================
 
-type ClaimsMap = Map.Map T.Text Value
+newtype ClaimsMap = ClaimsMap { unClaimsMap :: Map.Map T.Text Value }
+    deriving (Eq, Show)
 
 fromHashMap :: Object -> ClaimsMap
-fromHashMap = Map.fromList . StrictMap.toList
+fromHashMap = ClaimsMap . Map.fromList . StrictMap.toList
 
 removeRegisteredClaims :: ClaimsMap -> ClaimsMap
-removeRegisteredClaims input = Map.differenceWithKey (\_ _ _ -> Nothing) input registeredClaims
+removeRegisteredClaims (ClaimsMap input) = ClaimsMap $ Map.differenceWithKey (\_ _ _ -> Nothing) input registeredClaims
     where 
         registeredClaims = Map.fromList $ map (\e -> (e, Null)) ["iss", "sub", "aud", "exp", "nbf", "iat", "jti"]
 
@@ -494,7 +495,7 @@ instance ToJSON JWTClaimsSet where
                 , fmap ("nbf" .=) nbf
                 , fmap ("iat" .=) iat
                 , fmap ("jti" .=) jti
-            ] ++ Map.toList (removeRegisteredClaims unregisteredClaims)
+            ] ++ Map.toList (unClaimsMap $ removeRegisteredClaims unregisteredClaims)
 
 instance FromJSON JWTClaimsSet where
         parseJSON = withObject "JWTClaimsSet"

--- a/src/Web/JWT.hs
+++ b/src/Web/JWT.hs
@@ -386,6 +386,40 @@ binarySecret = Secret
 --
 -- > rsaKeySecret =<< readFile "foo.pem"
 --
+-- >>> :{
+--   -- A random example key created with `ssh-keygen -t rsa`
+--   fmap (\(Just (RSAKey pk)) -> pk) $ rsaKeySecret $ unlines
+--       [ "-----BEGIN RSA PRIVATE KEY-----"
+--       , "MIIEowIBAAKCAQEAkkmgbLluo5HommstpHr1h53uWfuN3CwYYYR6I6a2MzAHIMIv"
+--       , "8Ak2ha+N2UDeYsfVhZ/DOnE+PMm2RpYSaiYT0l2a7ZkmRSbcyvVFt3XLePJbmUgo"
+--       , "ieyccS4uYHeqRggdWH9His3JaR2N71N9iU0+mY5nu2+15iYw3naT/PSx01IzBqHN"
+--       , "Zie1z3FYX09FgOs31mcR8VWj8DefxbKE08AW+vDMT2AmUC2b+Gqk6SqRz29HuPBs"
+--       , "yyV4Xl9CgzcCWjuXTv6mevDygo5RVZg34U6L1iFRgwwHbrLcd2N97wlKz+OiDSgM"
+--       , "sbZWA0i2D9ZsDR9rdEdXzUIw6toIRYZfeI9QYQIDAQABAoIBAEXkh5Fqx0G/ZLLi"
+--       , "olwDo2u4OTkkxxJ6vutYsEJ4VHUAbWdpYB3/SN12kv9JzvbDI3FEc7JoiKPifAQd"
+--       , "j47HwpCvyGXc1jwT5UnTBgwxa5XNtZX2s+ex9Mzek6njgqcTGXI+3Z+j0qc2R6og"
+--       , "6cm/7jjPoSAcr3vWo2KmpO4muw+LbYoSGo0Jydoa5cGtkmDfsjjrMw7mDoRttdhw"
+--       , "WdhS+q2aJPFI7q7itoYUd7KLe3nOeM0zd35Pc8Qc6jGk+JZxQdXrb/NrSNgAATcN"
+--       , "GGS226Q444N0pAfc188IDcAtQPSJpzbs/1+TPzE4ov/lpHTr91hXr3RLyVgYBI01"
+--       , "jrggfAECgYEAwaC4iDSZQ+8eUx/zR973Lu9mvQxC2BZn6QcOtBcIRBdGRlXfhwuD"
+--       , "UgwVZ2M3atH5ZXFuQ7pRtJtj7KCFy7HUFAJC15RCfLjx+n39bISNp5NOJEdI+UM+"
+--       , "G2xMHv5ywkULV7Jxb+tSgsYIvJ0tBjACkif8ahNjgVJmgMSOgdHR2pkCgYEAwWkN"
+--       , "uquRqKekx4gx1gJYV7Y6tPWcsZpEcgSS7AGNJ4UuGZGGHdStpUoJICn2cFUngYNz"
+--       , "eJXOg+VhQJMqQx9c+u85mg/tJluGaw95tBAafspwvhKewlO9OhQeVInPbXMUwrJ0"
+--       , "PS3XV7c74nxm6Nn4QHlM07orn3lOiWxZF8BBSQkCgYATjwSU3ZtNvW22v9d3PxKA"
+--       , "7zXVitOFuF2usEPP9TOkjSVQHYSCw6r0MrxGwULry2IB2T9mH//42mlxkZVySfg+"
+--       , "PSw7UoKUzqnCv89Fku4sKzkNeRXp99ziMEJQLyuwbAEFTsUepQqkoxRm2QmfQmJA"
+--       , "GUHqBSNcANLR1wj+HA+yoQKBgQCBlqj7RQ+AaGsQwiFaGhIlGtU1AEgv+4QWvRfQ"
+--       , "B64TJ7neqdGp1SFP2U5J/bPASl4A+hl5Vy6a0ysZQEGV3cLH41e98SPdin+C5kiO"
+--       , "LCgEghGOWR2EaOUlr+sui3OvCueDGFynzTo27G+0bdPp+nnKgTvHtTqbTIUhsLX1"
+--       , "IvzbOQKBgH4q36jgBb9T3hjXtWyrytlmFtBdw0i+UiMvMlnOqujGhcnOk5UMyxOQ"
+--       , "sQI+/31jIGbmlE7YaYykR1FH3LzAjO4J1+m7vv5fIRdG8+sI01xTc8UAdbmWtK+5"
+--       , "TK1oLP43BHH5gRAfIlXj2qmap5lEG6If/xYB4MOs8Bui5iKaJlM5"
+--       , "-----END RSA PRIVATE KEY-----"
+--       ]
+-- :}
+-- PrivateKey {private_pub = PublicKey {public_size = 256, public_n = 1846..., public_e = 65537}, private_d = 8823..., private_p = 135..., private_q = 1358..., private_dP = 1373..., private_dQ = 9100..., private_qinv = 8859...}
+--
 rsaKeySecret :: String -> IO (Maybe Secret)
 rsaKeySecret k = do
     mKeyPair <- toKeyPair <$> readPrivateKey k PwNone

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
 packages:
 - '.'
 extra-deps: []
-resolver: lts-4.0
+resolver: lts-9.6

--- a/tests/src/Data/ByteString/ExtendedTests.hs
+++ b/tests/src/Data/ByteString/ExtendedTests.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.ByteString.ExtendedTests
   (
     main
   , defaultTestGroup
 ) where
 
-import           Control.Applicative
 import qualified Data.ByteString.Extended as BS
-import           Data.String              (fromString)
 import qualified Test.QuickCheck          as QC
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/tests/src/Data/Text/ExtendedTests.hs
+++ b/tests/src/Data/Text/ExtendedTests.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Text.ExtendedTests
   (
     main
   , defaultTestGroup
 ) where
 
-import           Control.Applicative
 import           Data.String           (fromString)
 import qualified Data.Text.Extended    as T
 import qualified Test.QuickCheck       as QC

--- a/tests/src/Web/JWTInteropTests.hs
+++ b/tests/src/Web/JWTInteropTests.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-|
 Tests that verify that the shape of the JSON used is matching the spec.
 
@@ -22,20 +23,18 @@ module Web.JWTInteropTests (
 ) where
 
 import           Prelude hiding (exp)
-import           Control.Applicative
 import           Control.Lens
 import           Data.Aeson.Lens
 import           Data.Aeson.Types
 import qualified Data.Map              as Map
 import           Data.Maybe
-import           Data.String           (IsString, fromString)
+import           Data.String           (fromString)
 import qualified Data.Text             as T
 import qualified Data.Text.Lazy        as TL
 import           Data.Time
 import qualified Data.Vector           as Vector
 import qualified Test.QuickCheck       as QC
 import           Test.Tasty
-import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 import           Test.Tasty.TH
 import           Web.JWT
@@ -55,6 +54,7 @@ prop_encode_decode_sub = shouldBeMaybeStringOrUri "sub" sub
 prop_encode_decode_iss :: JWTClaimsSet -> Bool
 prop_encode_decode_iss = shouldBeMaybeStringOrUri "iss" iss
 
+shouldBeMaybeStringOrUri :: ToJSON a => T.Text -> (a -> Maybe StringOrURI) -> a -> Bool
 shouldBeMaybeStringOrUri key' f claims' = 
     let json = toJSON claims' ^? key key'
     in json == (fmap (String . stringOrURIToText) $ f claims')
@@ -79,7 +79,7 @@ instance Arbitrary JWTClaimsSet where
                              <*> arbitrary
 
 instance Arbitrary ClaimsMap where
-    arbitrary = return Map.empty
+    arbitrary = return $ ClaimsMap Map.empty
 
 instance Arbitrary NumericDate where
     arbitrary = fmap (f . numericDate) (arbitrary :: QC.Gen NominalDiffTime)

--- a/tests/src/Web/JWTTests.hs
+++ b/tests/src/Web/JWTTests.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE BangPatterns, OverloadedStrings, ScopedTypeVariables, TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Web.JWTTests
   (
     main
   , defaultTestGroup
 ) where
 
-import           Control.Applicative
 import           Test.Tasty
 import           Test.Tasty.TH
 import           Test.Tasty.HUnit
@@ -14,12 +15,11 @@ import           Test.Tasty.QuickCheck
 import qualified Test.QuickCheck as QC
 import qualified Data.Map              as Map
 import qualified Data.Text             as T
-import qualified Data.Text.Encoding         as TE
 import qualified Data.Text.Lazy        as TL
 import qualified Data.ByteString as BS
 import           Data.Aeson.Types
 import           Data.Maybe
-import           Data.String (fromString, IsString)
+import           Data.String (fromString)
 import           Data.Time
 import           Web.JWT
 
@@ -52,7 +52,7 @@ case_decodeJWT = do
     True @=? isJust (fmap signature mJwt)
     let (Just unverified) = mJwt
     Just HS256 @=? alg (header unverified)
-    Just "payload" @=? Map.lookup "some" (unregisteredClaims $ claims unverified)
+    Just "payload" @=? Map.lookup "some" (unClaimsMap $ unregisteredClaims $ claims unverified)
 
 case_verify = do
     -- Generated with ruby-jwt
@@ -67,7 +67,7 @@ case_decodeAndVerifyJWT = do
     True @=? isJust mJwt
     let (Just verified) = mJwt
     Just HS256 @=? alg (header verified)
-    Just "payload" @=? Map.lookup "some" (unregisteredClaims $ claims verified)
+    Just "payload" @=? Map.lookup "some" (unClaimsMap $ unregisteredClaims $ claims verified)
 
 -- It must be impossible to get a VerifiedJWT if alg is "none"
 case_decodeAndVerifyJWTAlgoNone = do
@@ -111,7 +111,7 @@ case_decodeAndVerifySignatureInvalidInput = do
 case_encodeJWTNoMac = do
     let cs = def {
         iss = stringOrURI "Foo"
-      , unregisteredClaims = Map.fromList [("http://example.com/is_root", Bool True)]
+      , unregisteredClaims = ClaimsMap $ Map.fromList [("http://example.com/is_root", Bool True)]
     }
         jwt = encodeUnsigned cs
     -- Verify the shape of the JWT, ensure the shape of the triple of
@@ -125,7 +125,7 @@ case_encodeJWTNoMac = do
 case_encodeDecodeJWTNoMac = do
     let cs = def {
         iss = stringOrURI "Foo"
-      , unregisteredClaims = Map.fromList [("http://example.com/is_root", Bool True)]
+      , unregisteredClaims = ClaimsMap $ Map.fromList [("http://example.com/is_root", Bool True)]
     }
         mJwt = decode $ encodeUnsigned cs
     True @=? isJust mJwt
@@ -137,7 +137,7 @@ case_encodeDecodeJWT = do
         cs = def {
         iss = stringOrURI "Foo"
       , iat = numericDate now
-      , unregisteredClaims = Map.fromList [("http://example.com/is_root", Bool True)]
+      , unregisteredClaims = ClaimsMap $ Map.fromList [("http://example.com/is_root", Bool True)]
     }
         key = secret "secret-key"
         mJwt = decode $ encodeSigned HS256 key cs
@@ -149,7 +149,7 @@ case_tokenIssuer = do
     let iss' = stringOrURI "Foo"
         cs = def {
         iss = iss'
-      , unregisteredClaims = Map.fromList [("http://example.com/is_root", Bool True)]
+      , unregisteredClaims = ClaimsMap $ Map.fromList [("http://example.com/is_root", Bool True)]
     }
         key = secret "secret-key"
         t   = encodeSigned HS256 key cs
@@ -160,7 +160,7 @@ case_encodeDecodeJWTClaimsSetCustomClaims = do
         cs = def {
         iss = stringOrURI "Foo"
       , iat = numericDate now
-      , unregisteredClaims = Map.fromList [("http://example.com/is_root", Bool True)]
+      , unregisteredClaims = ClaimsMap $ Map.fromList [("http://example.com/is_root", Bool True)]
     }
     let secret' = secret "secret"
         jwt = decodeAndVerifySignature secret' $ encodeSigned HS256 secret' cs
@@ -239,7 +239,7 @@ instance Arbitrary JWTClaimsSet where
                              <*> arbitrary
 
 instance Arbitrary ClaimsMap where
-    arbitrary = return Map.empty
+    arbitrary = return $ ClaimsMap Map.empty
 
 instance Arbitrary NumericDate where
     arbitrary = fmap (f . numericDate) (arbitrary :: QC.Gen NominalDiffTime)

--- a/tests/src/Web/JWTTestsCompat.hs
+++ b/tests/src/Web/JWTTestsCompat.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE BangPatterns, OverloadedStrings, ScopedTypeVariables, TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- 
 - Turn of deprecation warnings as these tests deliberately use 
@@ -13,19 +15,11 @@ module Web.JWTTestsCompat
   , defaultTestGroup
 ) where
 
-import           Control.Applicative
 import           Test.Tasty
 import           Test.Tasty.TH
 import           Test.Tasty.HUnit
-import           Test.Tasty.QuickCheck
-import qualified Test.QuickCheck as QC
 import qualified Data.Map              as Map
-import qualified Data.Text             as T
-import qualified Data.Text.Lazy        as TL
 import           Data.Aeson.Types
-import           Data.Maybe
-import           Data.String (fromString, IsString)
-import           Data.Time
 import           Web.JWT
 
 defaultTestGroup :: TestTree
@@ -44,7 +38,7 @@ case_encodeDecodeJWTIntDateIat = do
         cs = def {
         iss = stringOrURI "Foo"
       , iat = intDate now
-      , unregisteredClaims = Map.fromList [("http://example.com/is_root", Bool True)]
+      , unregisteredClaims = ClaimsMap $ Map.fromList [("http://example.com/is_root", Bool True)]
     }
         key = secret "secret-key"
         mJwt = decode $ encodeSigned HS256 key cs


### PR DESCRIPTION
Hello and thanks for putting together this library. I was able to get it working with GitHub Apps' JWT-based authentication (https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-a-github-app) by adding RS256 support.

As part of this, I had to update to the latest stack LTS (to get `HsOpenSSL` to compile) and change the interface of `Secret` (see reasoning in commit message). I also addressed all the `-Wall` warnings, which unfortunately involved changing `ClaimsMap` to get around an overlapping instance on the `Map`.

Please let me know if you'd be willing to accept this PR and anything about it you'd like changed. Thanks!